### PR TITLE
Avoid breakage on empty camera images

### DIFF
--- a/cactusss/main.py
+++ b/cactusss/main.py
@@ -889,8 +889,11 @@ def tile_row_column_to_screen_xy(
 
 def cvmat_to_surface(image: cv2.Mat) -> pygame.surface.Surface:
     """Convert from OpenCV to pygame."""
-    image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     height, width, _ = image.shape
+    if height == 0 and width == 0:
+        return pygame.surface.Surface((1, 1))
+
+    image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     return pygame.image.frombuffer(image_rgb.tobytes(), (width, height), "RGB")
 
 


### PR DESCRIPTION
When no face is detected, the head pose estimator gives back an empty image. Originally, this would lead to a crash.

In this patch, we make the image 1x1 to avoid problems with empty images coming from OpenCV and interacting with pygame.